### PR TITLE
ENH: Remove reference to PyNifti

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -36,10 +36,6 @@ Jenkinson, mjenkinson@users.sourceforge.net.</p>
 <p>Questions about the <em>niftimatlib</em> library should be sent to John Ashburner
 (john@fil.ion.ucl.ac.uk).</p>
 
-<h3>PyNIfTI</h3>
-<p>Questions about <em>PyNIfTI</em> should be sent to Michael Hanke
-(michael.hanke@gmail.com).</p>
-
 <h2>Sourceforge Project</h2>
 <p>The project admins for the niftilib SourceForge site are:</p>
 <ul>

--- a/debian.html
+++ b/debian.html
@@ -16,12 +16,10 @@
 
 <h2>Debian packages</h2>
 <p>The NIfTI C libraries are available in all current Debian distributions, including Debian etch. No special configuration is needed to install them. Simply select them in the package manager.</p>
-<p>At the moment PyNIfTI is part of the Debian testing (lenny) and unstable (sid) distribution.</p>
 
 <h3>Latest package information</h3>
 <ul>
 <li>NIfTI C libraries: <a href="http://packages.qa.debian.org/n/nifticlib.html">status</a>, <a href="http://bugs.debian.org/cgi-bin/pkgreport.cgi?src=nifticlib">bugs</a></li>
-<li>PyNIfTI: <a href="http://packages.qa.debian.org/p/pynifti.html">status</a>, <a href="http://bugs.debian.org/cgi-bin/pkgreport.cgi?src=pynifti">bugs</a></li>
 </ul>
 
 <h2>Ubuntu packages</h2>
@@ -29,7 +27,6 @@
 <em>universe</em> repository. To install them, please enable the universe repository
 in your <code>/etc/apt/sources.list</code>. You can use your favorite package manager
 to download and install them, just like any other package.</p>
-<p>PyNIfTI is available for Ubuntu <em>gutsy</em> inside the universe repository.</p> 
 <h2>Inofficial packages</h2>
 <p>In some cases more recent binary packages or packages for other releases are provided in an
 inofficial repository. Please the <a href="http://apsy.gse.uni-magdeburg.de/debian">the list of available packages</a> and the page with <a href="http://apsy.gse.uni-magdeburg.de/main/index.psp?sec=1&page=hanke/debian&lang=en">information on how to setup your system to use this repository</a>.

--- a/home.html
+++ b/home.html
@@ -55,11 +55,6 @@ to contribute additonal functionality to the i/o library.</p>
       <td>1.2</td>
       <td>March 30, 2012</td>
     </tr>
-    <tr style="background-color:#bbb;">
-      <td>pynifti</td>
-      <td>0.20090205.1</td>
-      <td>February 5, 2009</td>
-    </tr>
   </tbody>
 </table>
 

--- a/niftilib_overview.html
+++ b/niftilib_overview.html
@@ -85,20 +85,6 @@ The following libraries are currently under development:
 	<li>Current release: 1.2</li>
 </ul>
 
-
-<h2>PyNIfTI</h2>
-
-<ul>
-	<li>Language: Python</li>
-	<li>Description: Python interface to the NIfTI I/O libraries.<br />
-	Using PyNIfTI one can easily read and write NIfTI and ANALYZE images from
-	within Python. The NiftiImage class provides Python-style access to the full
-	header information. Image data is made available via NumPy arrays.</li>
-	<li>Depends on: niftilib, Python 2.4 or later, NumPy</li>
-	<li>Authors: Michael Hanke</li>
-	<li>License: MIT License</li>
-</ul>
-
 <div id="footer">
 <a href="https://github.com/NIFTI-Imaging/NIFTI-Imaging.github.io/commits/master/niftilib_overview.html" target="_blank"> Page History </a>
 </div>

--- a/side.html
+++ b/side.html
@@ -17,7 +17,6 @@
 <li><a href="home.html" target="frame">Home</a></li>
 <li><a href="nifti1_overview.html" target="frame">About the nifti-1 format</a></li>
 <li><a href="niftilib_overview.html" target="frame">About the niftilib i/o libraries</a></li>
-<li><a href="pynifti" target="frame">About PyNIfTI</a></li>
 <li><a href="contacts.html" target="frame">Contacts</a></li>
 </ul>
 
@@ -33,7 +32,6 @@
 <li><a href="c_api_html/index.html" target="frame">nifti-1 C libraries API</a> (release 2.0.0, Jul. 2010)</li>
 <li><a href="java_api_html/index.html" target="frame">nifti-1 Java libraries API</a>  (release 0.2 3/20/06)</li>
 <li><a href="mat_api_html/README.txt" target="frame">nifti-1 Matlab libraries API</a>  (release 1.2 3/30/12)</li>
-<li><a href="pynifti/api" target="frame">PyNIfTI API</a></li>
 <!-- To be added later <li><a href="https://my.cdash.org/" target="frame">Dashboard for niftilib C library</a></li> -->
 </ul>
 


### PR DESCRIPTION
The PyNifti external reference site clearly states that
PyNifti should not be used.  It has been completely replaced
by the nibabel package.